### PR TITLE
Add Option To Use Groups' Real Path

### DIFF
--- a/src/TulsiGenerator/TulsiOptionSet.swift
+++ b/src/TulsiGenerator/TulsiOptionSet.swift
@@ -70,6 +70,10 @@ public enum TulsiOptionKey: String {
 
       // Whether test sources are filtered by the project's path filters.
       PathFiltersApplyToTestSources,
+    
+      // Generating project using real file path instead of dummy path.
+      // Reference: https://github.com/bazelbuild/tulsi/issues/55
+      ProjectGenerationUseRealFilePath,
 
       // Used by Tulsi to improve Bazel-caching of build flags.
       ProjectPrioritizesSwift,
@@ -334,6 +338,7 @@ public class TulsiOptionSet: Equatable {
     addBoolOption(.PathFiltersApplyToTestSources, .Generic, true)
     addBoolOption(.ProjectPrioritizesSwift, .Generic, true)
     addBoolOption(.SwiftForcesdSYMs, .Generic, false)
+    addBoolOption(.ProjectGenerationUseRealFilePath, .Generic, false)
     addBoolOption(.TreeArtifactOutputs, .Generic, true)
     addBoolOption(.Use64BitWatchSimulator, .Generic, false)
     addBoolOption(.DisableCustomLLDBInit, .Generic, false)

--- a/src/TulsiGenerator/TulsiOptionSet.swift
+++ b/src/TulsiGenerator/TulsiOptionSet.swift
@@ -338,7 +338,7 @@ public class TulsiOptionSet: Equatable {
     addBoolOption(.PathFiltersApplyToTestSources, .Generic, true)
     addBoolOption(.ProjectPrioritizesSwift, .Generic, true)
     addBoolOption(.SwiftForcesdSYMs, .Generic, false)
-    addBoolOption(.ProjectGenerationUseRealFilePath, .Generic, false)
+    addBoolOption(.ProjectGenerationUseRealFilePath, .Generic, true)
     addBoolOption(.TreeArtifactOutputs, .Generic, true)
     addBoolOption(.Use64BitWatchSimulator, .Generic, false)
     addBoolOption(.DisableCustomLLDBInit, .Generic, false)

--- a/src/TulsiGenerator/XcodeProjectGenerator.swift
+++ b/src/TulsiGenerator/XcodeProjectGenerator.swift
@@ -415,7 +415,8 @@ final class XcodeProjectGenerator {
   // Generates a PBXProject and a returns it along with a set of build, test and indexer targets.
   private func buildXcodeProjectWithMainGroup(_ mainGroup: PBXGroup,
                                               stubInfoPlistPaths: StubInfoPlistPaths) throws -> GeneratedProjectInfo {
-    let xcodeProject = PBXProject(name: config.projectName, mainGroup: mainGroup)
+    let useRealGroupsPath: Bool = config.options[.ProjectGenerationUseRealFilePath].commonValueAsBool ?? false
+    let xcodeProject = PBXProject(name: config.projectName, mainGroup: mainGroup, useRealGroupsPath: useRealGroupsPath)
 
     if let enabled = config.options[.SuppressSwiftUpdateCheck].commonValueAsBool, enabled {
       xcodeProject.lastSwiftUpdateCheck = "0710"
@@ -587,7 +588,7 @@ final class XcodeProjectGenerator {
 
     let referencePatcher = BazelXcodeProjectPatcher(fileManager: fileManager)
     profileAction("patching_bazel_relative_references") {
-      referencePatcher.patchBazelRelativeReferences(xcodeProject, workspaceRootURL)
+      referencePatcher.patchBazelRelativeReferences(useRealGroupsPath, xcodeProject, workspaceRootURL)
     }
     profileAction("patching_external_repository_references") {
       referencePatcher.patchExternalRepositoryReferences(xcodeProject)

--- a/src/TulsiGenerator/en.lproj/Options.strings
+++ b/src/TulsiGenerator/en.lproj/Options.strings
@@ -22,6 +22,9 @@
 "ProjectGenerationBazelStartupOptions" = "'build' startup options used for project generation.";
 "ProjectGenerationBazelStartupOptions_DESC" = "Modify this to add startup options for bazel invocations during project generation. Note: Modifying this will trigger a server restart between project generation and building, so the first build after generating the project will be slower than usual.";
 
+"ProjectGenerationUseRealFilePath" = "Use real Groups file path";
+"ProjectGenerationUseRealFilePath_DESC" = "Experimental Feature! By default Tulsi use dummy file path for Groups to prevents some issues related to project-generation. By turning this ON, the generated-project will use real path for Groups. This can let developer to maintain file easily on Xcode, but may can cause some issues.";
+
 "BazelBuildStartupOptions" = "'build' startup options";
 "BazelBuildStartupOptions_DESC" = "Startup options for bazel 'build' invocations.";
 "BazelBuildStartupOptionsDebug" = "Debug";


### PR DESCRIPTION
Reference: https://github.com/bazelbuild/tulsi/issues/55

## Motive

By default, Tulsi will using dummy groups and having per-file relative-paths from the mainGroup to solve some issue related to the project-generation. By doing these, the Groups that shown on the Xcode's Navigation Pane is not pointing to real path. 

That can lead to an issue where when creating new file from a selected group because the Xcode's Save Panel will pointing to root-workspace directory instead of the selected-group directory.

## What

This PR will add an option to toggle wether the project should be generated using dummy-Groups path or just use the real one.